### PR TITLE
Refactor code to not pass browser around, so createPDF is everything you need to create the PDF

### DIFF
--- a/.changeset/calm-avocados-fix.md
+++ b/.changeset/calm-avocados-fix.md
@@ -1,0 +1,6 @@
+---
+"bits-to-dead-trees": patch
+---
+
+Don't close browser if it's currently creating a PDF. We've added smoke tests, so
+this shouldn't happen again. Sorry!

--- a/app.js
+++ b/app.js
@@ -13,7 +13,6 @@ const PdfRequestBodySchema = JSON.parse(
 /**
  * @typedef {Parameters<import("playwright-core").Page["pdf"]>[0]} PdfOptions
  * @typedef {Parameters<import("playwright-core").Page["goto"]>[1]} GotoOptions
- * @typedef {import("playwright-core").Browser} Browser
  * @typedef {import("playwright-core").BrowserContextOptions} BrowserContextOptions
  */
 
@@ -35,7 +34,6 @@ export const defaultGotoOptions = /** @type {const} */ ({
 
 /**
  *
- * @param {Browser} browser
  * @param {string} url
  * @param {PdfOptions} pdfOptions
  * @param {BrowserContextOptions} browserContextOptions
@@ -43,26 +41,31 @@ export const defaultGotoOptions = /** @type {const} */ ({
  * @returns Buffer
  */
 const createPDF = async (
-  browser,
   url,
   pdfOptions = {},
   browserContextOptions = {},
   gotoOptions = {}
 ) => {
-  const context = await browser.newContext(browserContextOptions);
-  const page = await context.newPage();
+  const browser = await chromium.launch();
 
-  const response = await page.goto(url, gotoOptions);
-  if (response?.ok()) {
-    return page.pdf(pdfOptions);
+  try {
+    const context = await browser.newContext(browserContextOptions);
+    const page = await context.newPage();
+
+    const response = await page.goto(url, gotoOptions);
+    if (response?.ok()) {
+      return await page.pdf(pdfOptions);
+    }
+
+    return await Promise.reject({
+      error: true,
+      message: await response?.text(),
+      status: response?.status(),
+      statusText: response?.statusText(),
+    });
+  } finally {
+    await browser.close();
   }
-
-  return Promise.reject({
-    error: true,
-    message: await response?.text(),
-    status: response?.status(),
-    statusText: response?.statusText(),
-  });
 };
 
 /**
@@ -116,16 +119,13 @@ function build(opts = {}) {
         ...gotoOptions,
       };
 
-      const browser = await chromium.launch();
       try {
-        return await createPDF(browser, url, pdfOpts, contextOpts, gotoOpts);
+        return await createPDF(url, pdfOpts, contextOpts, gotoOpts);
       } catch (error) {
         // @ts-ignore
         response.code(error.status ?? 500);
 
         return error;
-      } finally {
-        browser.close();
       }
     }
   );

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import build from "../app";
+const app = build();
+
+describe("Smoke tests", () => {
+  it("sends the PDF on the success case", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/pdf",
+      payload: { url: "https://coding-robin.de" },
+    });
+
+    expect(response.payload.startsWith("%PDF")).toBeTruthy();
+  });
+
+  it("returns an error object when the page could not be loaded", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/pdf",
+      payload: {
+        url: "http://httpbin.org/status/404",
+      },
+    });
+
+    expect(response.statusCode).toEqual(404);
+    const error = JSON.parse(response.body);
+
+    expect(error).toMatchObject({
+      error: true,
+      status: 404,
+      statusText: "NOT FOUND",
+      message: "",
+    });
+  });
+});


### PR DESCRIPTION
I wasn't a fan of how we need to create a browser outside of the function. I do see the value of only one try/catch, however I think of them in two separate terms: The outer one is for general errors that can happen, the inner one for everything that can go wrong with the PDF creation.

Took the liberty to quickly add two smoke tests.