### PR TITLE
chore: Run format command with newest prettier version

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "esModuleInterop": true,
     "module": "ESNext",
 
-    "checkJs": true
-  }
+    "checkJs": true,
+  },
 }


### PR DESCRIPTION
I noticed that the defaults from most recent version of prettier cause the `check-format` command to fail, and thus one of the CI checks as well. This PR adds the changes resulting from running auto-formatting with the newest version of prettier.

Workflow run on my fork: https://github.com/AndrewADev/bits-to-dead-trees/actions/runs/7593895228