### PR TITLE
Removes tini from the Docker dependencies.

### DIFF
--- a/.changeset/little-cats-obey.md
+++ b/.changeset/little-cats-obey.md
@@ -1,0 +1,9 @@
+---
+"bits-to-dead-trees": minor
+---
+
+Removes tini from the Docker dependencies.
+
+This reduces the image size by one layer and one dependency by handling the signals
+ourselves. Fastify supports graceful shutdown, so it's pretty straightforward and
+one thing less to keep in mind.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,10 @@ ENV SERVER_ADDRESS=0.0.0.0
 
 WORKDIR /app
 
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends tini && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY ["package.json", "package-lock.json*", "./"]
 
 RUN npm install --omit=dev --ignore-scripts
 
 COPY ["server.js", "app.js", "pdf_request_body.json", "./"]
 
-ENTRYPOINT ["tini", "-v", "--"]
 CMD ["node", "server.js"]

--- a/server.js
+++ b/server.js
@@ -18,3 +18,13 @@ const server = app({
 });
 
 await server.listen({ port: +PORT, host: SERVER_ADDRESS });
+
+const shutdown = async () => {
+  console.log("Shutting down server");
+  await server.close();
+  // eslint-disable-next-line n/no-process-exit
+  process.exit(1);
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);


### PR DESCRIPTION
This reduces the image size by one layer and one dependency by handling the signals
ourselves. Fastify supports graceful shutdown, so it's pretty straightforward and
one thing less to keep in mind.
